### PR TITLE
Added parallelism to train.jl and improved efficiency of types.jl

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -10,43 +10,42 @@
 # regularizer are the two standard gradient descent parameters that control
 # how fast the descent happens and prevent the descent from over-aggressive
 # training in any direction.
-
 function train(rating_set::RatingSet,
                max_rank;
                min_epochs=0,
                max_epochs=100,
                learning_rate=0.001,
                regularizer=0.02)
-    user_features = [0.1 for r=1:length(rating_set.user_to_index), c=1:max_rank]
-    item_features = [0.1 for r=1:length(rating_set.item_to_index), c=1:max_rank]
-    residuals = [Residual(rating.value, 0.0, 0.0) for rating in rating_set.training_set]
-    num_ratings = length(rating_set.training_set)
     p = Progress(max_rank, 1, "Computing truncated rank $(max_rank) SVD ")
+    training_set = convert(SharedArray, rating_set.training_set)
+    user_features = SharedArray(Float32, (length(rating_set.user_to_index), max_rank), init = S -> S[Base.localindexes(S)] = 0.1)
+    item_features = SharedArray(Float32, (length(rating_set.item_to_index), max_rank), init = S -> S[Base.localindexes(S)] = 0.1)
+    residuals = SharedArray(Residual, size(rating_set.training_set), init = [Residual(rating.value, 0.0, 0.0) for rating in rating_set.training_set])
+    num_ratings = length(rating_set.training_set)
     for rank=1:max_rank
-        errors = [0.0, Inf, Inf]
-        for i=1:max_epochs
-            for j=1:num_ratings
-                rating, residual = rating_set.training_set[j], residuals[j]
-                item_feature = item_features[rating.item, rank]
-                user_feature = user_features[rating.user, rank]
-                residual.curr_error = residual.value - user_feature * item_feature
-                error_diff = residual.prev_error - residual.curr_error
-                errors[1] += error_diff * error_diff
-                residual.prev_error = residual.curr_error
-                item_features[rating.item, rank] += learning_rate * (residual.curr_error * user_feature - regularizer * item_feature)
-                user_features[rating.user, rank] += learning_rate * (residual.curr_error * item_feature - regularizer * user_feature)
-            end
-            # distance decreases, then increases, then decreases. we want to catch it on second decrease
-            if i > min_epochs && errors[1] < errors[2] && errors[2] > errors[3]
-                break
-            end
-            errors[1], errors[2], errors[3] = 0.0, errors[1], errors[2]
+      errors = SharedArray(Float32, (3,), init = S -> [0.0, Inf, Inf])
+      for i=1:max_epochs
+        @sync @parallel for j=1:num_ratings
+          rating, residual = training_set[j], residuals[j]
+          item_feature = item_features[rating.item, rank]
+          user_feature = user_features[rating.user, rank]
+          error_diff = residual.prev_error - residual.curr_error
+          errors[1] += error_diff * error_diff
+          residuals[j] = Residual(residual.value, -user_feature * item_feature + residual.value, residual.curr_error)
+          item_features[rating.item, rank] += learning_rate * (residual.curr_error * user_feature - regularizer * item_feature)
+          user_features[rating.user, rank] += learning_rate * (residual.curr_error * item_feature - regularizer * user_feature)
         end
-        for residual in residuals
-            residual.value = residual.curr_error
-            residual.prev_error = 0.0
+        # distance decreases, then increases, then decreases. we want to catch it on second decrease
+        if i > min_epochs && errors[1] < errors[2] && errors[2] > errors[3]
+          break
         end
-        next!(p)
+        errors[1], errors[2], errors[3] = 0.0, errors[1], errors[2]
+      end
+      for j=1:num_ratings
+        residual = residuals[j]
+        residuals[j] = Residual(residual.curr_error, residual.curr_error, 0)
+      end
+      next!(p)
     end
 
     # We end up with just the U and V matrices of the singular value

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,14 +1,14 @@
 # A single rating. The user and item are both represented by integer ids. A map
 # between ids and user/item names is stored elsewhere, both in the rating set
 # and the model.
-type Rating
+immutable Rating
     user::Int32
     item::Int32
     value::Float32
 end
 
 # An internal type used only by the train function for caching between epochs.
-type Residual
+immutable Residual
     value::Float32
     curr_error::Float32
     prev_error::Float32
@@ -38,7 +38,7 @@ type RatingsModel
     # matrix. U is a (number of users) x (number of features) matrix, S is
     # a list of (number of features) singular values, and V is a (number of
     # items) x (number of features) matrix.
-    U::Array{Float32,2}
-    S::Array{Float32,1}
-    V::Array{Float32,2}
+    U::AbstractArray{Float32,2}
+    S::AbstractArray{Float32,1}
+    V::AbstractArray{Float32,2}
 end


### PR DESCRIPTION
I added parrellism so that you can train it with several processes. I felt conflicted about whether or not I should force types.jl to be included using the "@everywhere" notation, but I left that up to you. I also utilized shared arrays to speed up execution and finally I had to make some types immutable so that they are bittypes. This allows them to be used in SharedArrays and should overall improve the speed of execution since it's more efficient.
